### PR TITLE
fix(#3): 合并membrane时,基础类型的合并成对象,比如name

### DIFF
--- a/src/Store.js
+++ b/src/Store.js
@@ -21,7 +21,13 @@ export class Store {
           if (Array.isArray(objValue)) {
             return [...srcValue]
           }
-          return { ...objValue, ...srcValue }
+          if (
+            typeof objValue === 'object' &&
+            Object.prototype.toString.call(objValue) ===
+              Object.prototype.toString.call(srcValue)
+          ) {
+            return { ...objValue, ...srcValue }
+          }
         }
       )
     }
@@ -33,7 +39,13 @@ export class Store {
           if (Array.isArray(objValue)) {
             return [...srcValue]
           }
-          return { ...objValue, ...srcValue }
+          if (
+            typeof objValue === 'object' &&
+            Object.prototype.toString.call(objValue) ===
+              Object.prototype.toString.call(srcValue)
+          ) {
+            return { ...objValue, ...srcValue }
+          }
         }
       )
     }

--- a/src/Store.js
+++ b/src/Store.js
@@ -21,13 +21,6 @@ export class Store {
           if (Array.isArray(objValue)) {
             return [...srcValue]
           }
-          if (
-            typeof objValue === 'object' &&
-            Object.prototype.toString.call(objValue) ===
-              Object.prototype.toString.call(srcValue)
-          ) {
-            return { ...objValue, ...srcValue }
-          }
         }
       )
     }
@@ -38,13 +31,6 @@ export class Store {
         (objValue, srcValue) => {
           if (Array.isArray(objValue)) {
             return [...srcValue]
-          }
-          if (
-            typeof objValue === 'object' &&
-            Object.prototype.toString.call(objValue) ===
-              Object.prototype.toString.call(srcValue)
-          ) {
-            return { ...objValue, ...srcValue }
           }
         }
       )


### PR DESCRIPTION
合并前增加判断,必须是对象,并且类型是“===”,否侧用 _. mergeWith 默认的合并规则